### PR TITLE
[FIX] do not only register the first found keyboard

### DIFF
--- a/c_src/driverkit.cpp
+++ b/c_src/driverkit.cpp
@@ -244,7 +244,7 @@ bool consume_kb_iter(Func consume) {
     if(iter == IO_OBJECT_NULL) return false;
     bool result = false;
     for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter))
-        result = result || consume(curr);
+        result = consume(curr) || result;
     IOObjectRelease(iter);
     return result;
 }


### PR DESCRIPTION
this fixes a tiny bug when looping the keyboards dictionary.

currently whenever one callback returned true, the callback will not be called anymore because of lazy evaluation.
this leads to only the first found keyboard being listed/registered. for anyone using external keyboards on a macbook this makes kanata useless. 

i think the intended behavior is to go through all found keyboards and return true if any of them was a success.