### PR TITLE
Bumb Karabiner-DriverKit-VirtualHIDDevice to v5.0.0

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() {
             build.include(
                 "c_src/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit",
             );
-            build.include("c_src/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include");
+            build.include("c_src/Karabiner-DriverKit-VirtualHIDDevice/src/Daemon/vendor/include");
         }
     }
 

--- a/c_src/driverkit.cpp
+++ b/c_src/driverkit.cpp
@@ -70,7 +70,9 @@ int init_sink() {
 
     client->connected.connect([copy] {
         std::cout << "connected" << std::endl;
-        copy->async_virtual_hid_keyboard_initialize(pqrs::hid::country_code::us);
+        pqrs::karabiner::driverkit::virtual_hid_device_service::virtual_hid_keyboard_parameters parameters;
+        parameters.set_country_code(pqrs::hid::country_code::us);
+        copy->async_virtual_hid_keyboard_initialize(parameters);
     });
 
     client->closed.connect([] { std::cout << "closed" << std::endl; });


### PR DESCRIPTION
Encountered issues similar to those described in [issue #1317](https://github.com/jtroo/kanata/issues/1317). Updating `DriverKit` to v5.0.0 and recompiling Kanata resolved the problem, restoring normal functionality on macOS 15.0.1.
