### PR TITLE
Expose keyboard VID/PID via new non-breaking list_keyboards_with_ids API

### DIFF
--- a/c_src/driverkit.hpp
+++ b/c_src/driverkit.hpp
@@ -99,6 +99,7 @@ extern "C" {
     void release();
 
     void list_keyboards();
+    void list_keyboards_with_ids();
     bool device_matches(const char* product);
     bool driver_activated();
     bool register_device(char* product);

--- a/examples/list_with_ids.rs
+++ b/examples/list_with_ids.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Call the new API; output is written to stdout by the C layer
+    #[allow(unused_unsafe)]
+    {
+        karabiner_driverkit::list_keyboards_with_ids();
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod interface {
         pub fn send_key(e: *mut DKEvent) -> i32;
         pub fn wait_key(e: *mut DKEvent) -> i32;
         pub fn list_keyboards();
+        pub fn list_keyboards_with_ids();
         pub fn driver_activated() -> bool;
         pub fn device_matches(product: *mut c_char) -> bool;
         pub fn register_device(product: *mut c_char) -> bool;
@@ -64,6 +65,11 @@ pub fn release() {
 /// Lists the valid keyboard names to be registered with register_device()
 pub fn list_keyboards() {
     unsafe { interface::list_keyboards() }
+}
+
+/// Lists keyboard names with vendor/product IDs (tab-separated, decimal) and exits.
+pub fn list_keyboards_with_ids() {
+    unsafe { interface::list_keyboards_with_ids() }
 }
 
 /// Registers a device for IO control


### PR DESCRIPTION
### Title
Expose keyboard VID/PID via new non-breaking list_keyboards_with_ids API

### Summary
Add a minimal, backward-compatible enumeration API that prints keyboard name plus Vendor ID and Product ID (VID/PID) to stdout, mirroring the existing list_keyboards style. This enables downstream tools (e.g., Kanata) to show VID/PID on macOS without re-implementing IOKit enumeration.

### Motivation
- Downstream projects want VID/PID to support device targeting and diagnostics.
- Current API only prints names; consumers must duplicate IOKit to get IDs.
- Kanata reviewer suggested first exposing this via the driverkit crate before adding IOKit code downstream. See Kanata PR #1723: https://github.com/jtroo/kanata/pull/1723
- References: crate docs on docs.rs: https://docs.rs/crate/karabiner-driverkit/latest and DriverKit notes: https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/blob/main/DEVELOPMENT.md

### Problem
- list_keyboards() prints only kIOHIDProductKey (name).
- No public path to fetch kIOHIDVendorIDKey / kIOHIDProductIDKey.
- Each downstream either forgoes VID/PID or re-implements IOKit enumeration.

### Proposed solution
- Add a new C API and Rust wrapper that prints one line per keyboard with name + VID/PID.
- Keep stdout-based pattern for simplicity and consistency with existing API.

New APIs:
```c
// C++
extern "C" void list_keyboards_with_ids();
```
```rust
// Rust
pub fn list_keyboards_with_ids();
```

Output format (TSV):
- One line per device: <name>\t<vendor_id>\t<product_id>
- Decimal numbers; 0 if a numeric value is unavailable
- Tabs in names are replaced with spaces for stable parsing

Examples:
- Apple Internal Keyboard / Trackpad    1452    628
- Logitech MX Keys                      1133    49970

### Implementation details
- Reuse existing HID keyboard enumeration in c_src/driverkit.cpp.
- For each device:
  - Name: kIOHIDProductKey (CFString → UTF-8)
  - VID: kIOHIDVendorIDKey (CFNumber → u16, decimal)
  - PID: kIOHIDProductIDKey (CFNumber → u16, decimal)
- Skip Karabiner virtual devices per current logic.
- Add the C symbol and a thin Rust wrapper; do not change list_keyboards().

### Backward compatibility
- Non-breaking, additive API.
- Existing behavior unchanged.
- Version bump: patch or minor (maintainer preference).

### Testing plan
- Manual: run and verify lines match current enumeration; spot-check IDs.
- Example program provided to print TSV (examples/list_with_ids.rs).
- Basic compile checks on macOS.

### Documentation
- Note the new function in README with its output contract and intended usage.
- Clarify that VID/PID are decimal; consumers can format as hex if desired.

### Alternatives considered
- Structured FFI (arrays/structs) across the boundary:
  - Cleaner but more intrusive (alloc/ownership/ABI). stdout-based is consistent with this crate’s minimal design.
- Do nothing and let downstream enumerate via IOKit:
  - Duplicates low-level code across projects.
- Extend pqrs-org repos:
  - Not required for this feature; current crate already uses IOKit and can read the properties.

### Risks and mitigations
- Output stability: contract is explicit (TSV, three columns, decimal, missing → 0). Tabs in names replaced with spaces.

### Request for feedback
- Naming preference: list_keyboards_with_ids vs. list_keyboards_verbose?
- TSV acceptable?
- Include unconditionally or behind a feature flag?
- Version bump policy for additive API.
