### PR TITLE
fix: close the correct IOHIDDeviceRef to release keyboard seizure

### DIFF
--- a/c_src/driverkit.cpp
+++ b/c_src/driverkit.cpp
@@ -191,18 +191,18 @@ void device_connected_callback(void* context, io_iterator_t iter) {
     for (mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
         uint64_t curr_hash = hash_device(curr);
         if ( curr_hash == device_hash )
-            capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, curr));
+            capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, curr), curr_hash);
         IOObjectRelease(curr);
     }
 }
 
 void close_registered_devices() {
-    for(auto hash : registered_devices_hashes) {
-        IOHIDDeviceRef device_ref = get_device_by_hash(hash);
+    for(auto& [hash, device_ref] : opened_device_refs) {
         kern_return_t kr = IOHIDDeviceClose(device_ref, kIOHIDOptionsTypeSeizeDevice);
-        if(kr != KERN_SUCCESS) { print_iokit_error("IOHIDDeviceClose", kr); return; }
+        if(kr != KERN_SUCCESS) { print_iokit_error("IOHIDDeviceClose", kr); }
         CFRelease(device_ref);
     }
+    opened_device_refs.clear();
 }
 
 void init_keyboards_dictionary() {
@@ -246,14 +246,16 @@ void subscribe_to_notification(const char* notification_type, void* cb_arg, call
         IOObjectRelease(obj);
 }
 
-bool capture_device(IOHIDDeviceRef device_ref) {
+bool capture_device(IOHIDDeviceRef device_ref, uint64_t device_hash) {
     kern_return_t kr = IOHIDDeviceOpen(device_ref, kIOHIDOptionsTypeSeizeDevice);
     if(kr != kIOReturnSuccess) {
         print_iokit_error("IOHIDDeviceOpen", kr, CFStringToStdString(get_device_name(device_ref)));
+        CFRelease(device_ref);
         return false;
     }
     IOHIDDeviceRegisterInputValueCallback(device_ref, input_callback, NULL);
     IOHIDDeviceScheduleWithRunLoop(device_ref, listener_loop, kCFRunLoopDefaultMode);
+    opened_device_refs[device_hash] = device_ref;
     return true;
 }
 
@@ -263,7 +265,7 @@ bool capture_registered_devices() {
     return consume_devices([](mach_port_t c) {
         uint64_t device_hash = hash_device(c);
         if ( registered_devices_hashes.find(device_hash) != registered_devices_hashes.end() ) {
-            bool captured = capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, c));
+            bool captured = capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, c), device_hash);
             if ( captured ) {
                 void* dev_hash = reinterpret_cast<void*>(static_cast<uintptr_t>(device_hash));
                 subscribe_to_notification(kIOMatchedNotification, dev_hash, device_connected_callback);

--- a/c_src/driverkit.hpp
+++ b/c_src/driverkit.hpp
@@ -8,6 +8,7 @@
 #include <IOKit/hid/IOHIDLib.h>
 #include <IOKit/hidsystem/IOHIDShared.h>
 #include <set>
+#include <unordered_map>
 
 /* The name was changed from "Master" to "Main" in Apple SDK 12.0 (Monterey) */
 #if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
@@ -41,6 +42,10 @@ IONotificationPortRef notification_port = IONotificationPortCreate(kIOMainPortDe
 std::thread listener_thread;
 CFRunLoopRef listener_loop;
 std::set<uint64_t> registered_devices_hashes;
+// Maps device hash → the IOHIDDeviceRef that was opened with kIOHIDOptionsTypeSeizeDevice.
+// close_registered_devices() must close the SAME ref that capture_device() opened;
+// creating a new ref via IOHIDDeviceCreate() and closing that does NOT release the seizure.
+std::unordered_map<uint64_t, IOHIDDeviceRef> opened_device_refs;
 
 int fd[2];
 CFMutableDictionaryRef matching_dictionary = NULL;
@@ -80,7 +85,7 @@ void input_callback(void* context, IOReturn result, void* sender, IOHIDValueRef 
 template <typename Func>
 bool consume_devices(Func consume);
 bool capture_registered_devices();
-bool capture_device(IOHIDDeviceRef device_ref);
+bool capture_device(IOHIDDeviceRef device_ref, uint64_t device_hash);
 
 int  init_sink();
 int  exit_sink();


### PR DESCRIPTION
## Problem

`close_registered_devices()` creates a **new** `IOHIDDeviceRef` via `get_device_by_hash()` → `IOHIDDeviceCreate()` and calls `IOHIDDeviceClose()` on that fresh ref. Since this ref was never opened with `kIOHIDOptionsTypeSeizeDevice`, the close is effectively a no-op — the original seizure from `capture_device()` persists forever.

This causes **keyboard bricking** when a consumer (like kanata) tries to release and re-grab devices after a DriverKit daemon restart:
1. `close_registered_devices()` fails silently (closes wrong ref)
2. The original `IOHIDDeviceRef` still holds exclusive seizure
3. `IOHIDDeviceOpen()` on re-grab fails with `(iokit/common) exclusive access and device already open`
4. The physical keyboard becomes permanently unusable

## Root Cause

`IOHIDDeviceCreate()` returns a **different** `IOHIDDeviceRef` each time, even for the same physical device. `IOHIDDeviceClose()` only releases the seizure on the **exact ref** that was passed to `IOHIDDeviceOpen()`. The old code discarded that ref immediately and tried to recreate it later — which doesn't work.

## Fix

- Store the `IOHIDDeviceRef` returned by `IOHIDDeviceCreate()` in `capture_device()` using a `std::unordered_map<uint64_t, IOHIDDeviceRef>` keyed by device hash
- In `close_registered_devices()`, iterate the stored refs instead of creating new ones
- `CFRelease` the device ref on open failure (was leaked before)
- Don't early-return on close failure (was skipping remaining devices)

## Testing

Tested with [kanata PR jtroo/kanata#1950](https://github.com/jtroo/kanata/pull/1950) (DriverKit recovery):

1. Start kanata with caps→esc remap
2. Kill the Karabiner DriverKit daemon (`launchctl bootout`)
3. Keyboard returns to normal (seizure released correctly)
4. Restart the daemon (`launchctl bootstrap`)
5. Kanata re-grabs input — remapping resumes with **no errors**

Without this fix, step 3 fails silently and step 5 gets `IOHIDDeviceOpen error: exclusive access`.

## Log evidence (after fix)

```
17:18:00.6028 WARN DriverKit output lost during write — releasing input devices
17:18:00.6085 INFO Input devices released. Keyboard is usable (without remapping)...
17:18:26.7571 INFO DriverKit output recovered — re-grabbing input devices
17:18:26.7572 INFO keyboard grabbed, entering event processing loop
```

No `IOHIDDeviceOpen error` or `IOHIDDeviceClose error` in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)