### PR TITLE
fix: subscribe to device notifications for not-yet-connected devices

### DIFF
--- a/c_src/driverkit.cpp
+++ b/c_src/driverkit.cpp
@@ -264,17 +264,24 @@ bool capture_device(IOHIDDeviceRef device_ref, uint64_t device_hash) {
 bool capture_registered_devices() {
     // Register the notification port to the run loop, essential for receiving re-connect events so we can re-capture devices
     CFRunLoopAddSource(listener_loop, IONotificationPortGetRunLoopSource(notification_port), kCFRunLoopDefaultMode);
-    return consume_devices([](mach_port_t c) {
+
+    // Try to capture devices that are already connected
+    bool any_captured = consume_devices([](mach_port_t c) {
         uint64_t device_hash = hash_device(c);
         if ( registered_devices_hashes.find(device_hash) != registered_devices_hashes.end() ) {
-            bool captured = capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, c), device_hash);
-            if ( captured ) {
-                void* dev_hash = reinterpret_cast<void*>(static_cast<uintptr_t>(device_hash));
-                subscribe_to_notification(kIOMatchedNotification, dev_hash, device_connected_callback);
-            }
-            return captured;
+            return capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, c), device_hash);
         } else return false;
     });
+
+    // Subscribe to notifications for ALL registered devices, regardless of
+    // whether they are currently connected. This ensures that devices which
+    // appear later (e.g. plugged in after startup) are automatically captured.
+    for (auto hash : registered_devices_hashes) {
+        void* dev_hash = reinterpret_cast<void*>(static_cast<uintptr_t>(hash));
+        subscribe_to_notification(kIOMatchedNotification, dev_hash, device_connected_callback);
+    }
+
+    return any_captured;
 }
 
 IOHIDDeviceRef get_device_by_hash(uint64_t device_hash) {

--- a/c_src/driverkit.hpp
+++ b/c_src/driverkit.hpp
@@ -202,19 +202,20 @@ extern "C" {
     bool driver_activated();
     bool register_device(const char* product_key);
     bool register_device_hash(uint64_t device_hash) {
+        // Always register the hash so that the device will be captured when
+        // it appears, even if it is not currently connected.
+        registered_devices_hashes.insert(device_hash);
+
+        // Check if the device is currently connected (for the return value).
         return consume_devices([device_hash](mach_port_t current_device) {
-            // Don't open karabiner
+            // Don't match karabiner devices
             CFStringRef name = get_product_name_cf(current_device);
             if( isSubstring(from_cstr("Karabiner"), name) ) {
                 if (name) CFRelease(name);
                 return false;
             }
             if (name) CFRelease(name);
-            if ( hash_device(current_device) == device_hash ) {
-                registered_devices_hashes.insert(device_hash);
-                return true;
-            }
-            return false;
+            return hash_device(current_device) == device_hash;
         });
     }
     const DeviceData* get_device_list(size_t* array_length);


### PR DESCRIPTION
## Problem

`capture_registered_devices()` only subscribes to `kIOMatchedNotification` for devices that are successfully captured at startup. If a registered device isn't connected, no notification is registered — so it will never be auto-captured when plugged in later.

Similarly, `register_device_hash()` only stores the hash if the device is currently connected, making it impossible to pre-register a disconnected device.

This is the driverkit-side blocker for [jtroo/kanata#1479](https://github.com/jtroo/kanata/issues/1479).

## Fix

**`capture_registered_devices()`** — separate capture from notification subscription. Notifications are now subscribed for all registered hashes in a second pass, not only after successful capture.

**`register_device_hash()`** — always insert hash into `registered_devices_hashes`, then check if the device is connected. Return value still reflects current presence (backward compatible).

## Testing

- Device connected at startup — captured and notification subscribed (unchanged behavior)
- Device disconnected at startup, plugged in later — notification fires and device is auto-captured (new behavior)
- Device disconnect/reconnect cycle — still works as before