### PR TITLE
feat: add VID:PID-based device registration and matching

### DIFF
--- a/c_src/driverkit.cpp
+++ b/c_src/driverkit.cpp
@@ -197,6 +197,27 @@ void device_connected_callback(void* context, io_iterator_t iter) {
     }
 }
 
+void device_connected_vidpid_callback(void* context, io_iterator_t iter) {
+    uint64_t vidpid = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(context));
+    uint32_t vid = static_cast<uint32_t>(vidpid >> 32);
+    uint32_t pid = static_cast<uint32_t>(vidpid & 0xFFFFFFFF);
+    CFStringRef karabiner = from_cstr("Karabiner");
+    for (mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
+        uint32_t curr_vid = get_number_property(curr, kIOHIDVendorIDKey);
+        uint32_t curr_pid = get_number_property(curr, kIOHIDProductIDKey);
+        if (curr_vid == vid && curr_pid == pid) {
+            CFStringRef name = get_product_name_cf(curr);
+            if (name && !isSubstring(karabiner, name)) {
+                uint64_t curr_hash = hash_device(curr);
+                capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, curr), curr_hash);
+            }
+            if (name) CFRelease(name);
+        }
+        IOObjectRelease(curr);
+    }
+    CFRelease(karabiner);
+}
+
 void close_registered_devices() {
     for(auto& [hash, device_ref] : opened_device_refs) {
         kern_return_t kr = IOHIDDeviceClose(device_ref, kIOHIDOptionsTypeSeizeDevice);
@@ -267,15 +288,34 @@ bool capture_registered_devices() {
     // Try to capture devices that are already connected
     bool any_captured = consume_devices([](mach_port_t c) {
         uint64_t device_hash = hash_device(c);
+        // Match by hash
         if ( registered_devices_hashes.find(device_hash) != registered_devices_hashes.end() ) {
             return capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, c), device_hash);
-        } else return false;
+        }
+        // Match by VID:PID
+        uint32_t vid = get_number_property(c, kIOHIDVendorIDKey);
+        uint32_t pid = get_number_property(c, kIOHIDProductIDKey);
+        uint64_t vidpid = (static_cast<uint64_t>(vid) << 32) | pid;
+        if ( registered_device_vidpids.find(vidpid) != registered_device_vidpids.end() ) {
+            CFStringRef name = get_product_name_cf(c);
+            CFStringRef karabiner = from_cstr("Karabiner");
+            bool is_karabiner = name && isSubstring(karabiner, name);
+            release_strings(karabiner, name);
+            if (!is_karabiner) {
+                return capture_device(IOHIDDeviceCreate(kCFAllocatorDefault, c), device_hash);
+            }
+        }
+        return false;
     });
     // Subscribe to notifications for ALL registered devices, regardless of whether they are currently connected.
     // This ensures that devices which appear later (e.g. plugged in after startup) are automatically captured.
     for (auto hash : registered_devices_hashes) {
         void* dev_hash = reinterpret_cast<void*>(static_cast<uintptr_t>(hash));
         subscribe_to_notification(kIOMatchedNotification, dev_hash, device_connected_callback);
+    }
+    for (auto vidpid : registered_device_vidpids) {
+        void* ctx = reinterpret_cast<void*>(static_cast<uintptr_t>(vidpid));
+        subscribe_to_notification(kIOMatchedNotification, ctx, device_connected_vidpid_callback);
     }
     return any_captured;
 }
@@ -401,8 +441,24 @@ extern "C" {
      * Loads a the karabiner kernel extension that will send key events
      * back to the OS.
      */
+    bool register_device_vidpid(uint32_t vendor_id, uint32_t product_id) {
+        uint64_t vidpid = (static_cast<uint64_t>(vendor_id) << 32) | product_id;
+        registered_device_vidpids.insert(vidpid);
+        return consume_devices([vendor_id, product_id](mach_port_t current_device) {
+            CFStringRef name = get_product_name_cf(current_device);
+            CFStringRef karabiner = from_cstr("Karabiner");
+            if (name && isSubstring(karabiner, name)) {
+                release_strings(karabiner, name);
+                return false;
+            }
+            release_strings(karabiner, name);
+            return get_number_property(current_device, kIOHIDVendorIDKey) == vendor_id
+                && get_number_property(current_device, kIOHIDProductIDKey) == product_id;
+        });
+    }
+
     int grab() {
-        if (!registered_devices_hashes.size() ) {
+        if (!registered_devices_hashes.size() && !registered_device_vidpids.size()) {
             std::cout << "At least one device has to be registered via register_device()" << std::endl;
             return 1;
         }
@@ -524,7 +580,7 @@ extern "C" {
         #ifdef USE_KEXT
         return true;
         #else
-        if (!registered_devices_hashes.size()) return false;
+        if (!registered_devices_hashes.size() && !registered_device_vidpids.size()) return false;
         if (pipe(fd) == -1) { std::cerr << "pipe error: " << errno << std::endl; return false; }
         fire_listener_thread();
         return true;

--- a/c_src/driverkit.hpp
+++ b/c_src/driverkit.hpp
@@ -42,6 +42,7 @@ IONotificationPortRef notification_port = IONotificationPortCreate(kIOMainPortDe
 std::thread listener_thread;
 CFRunLoopRef listener_loop;
 std::set<uint64_t> registered_devices_hashes;
+std::set<uint64_t> registered_device_vidpids;
 // Maps device hash → the IOHIDDeviceRef that was opened with kIOHIDOptionsTypeSeizeDevice.
 // close_registered_devices() must close the SAME ref that capture_device() opened;
 // creating a new ref via IOHIDDeviceCreate() and closing that does NOT release the seizure.
@@ -79,6 +80,7 @@ struct DeviceData {
 using callback_type = void(*)(void*, io_iterator_t);
 void subscribe_to_notification(const char* notification_type, void* cb_arg, callback_type callback);
 void device_connected_callback(void* context, io_iterator_t iter);
+void device_connected_vidpid_callback(void* context, io_iterator_t iter);
 void fire_listener_thread();
 void init_keyboards_dictionary();
 void close_registered_devices();
@@ -201,6 +203,7 @@ extern "C" {
     bool device_matches(const char* product);
     bool driver_activated();
     bool register_device(const char* product_key);
+    bool register_device_vidpid(uint32_t vendor_id, uint32_t product_id);
     bool register_device_hash(uint64_t device_hash) {
         // Always register the hash so that the device will be captured when
         // it appears, even if it is not currently connected.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod interface {
         pub fn device_matches(product: *mut c_char) -> bool;
         pub fn register_device(product: *mut c_char) -> bool;
         pub fn register_device_hash(hash: u64) -> bool;
+        pub fn register_device_vidpid(vendor_id: u32, product_id: u32) -> bool;
         pub fn get_device_list(array_length: *mut usize) -> *const DeviceData;
         pub fn is_sink_ready() -> bool;
         pub fn release_input_only();
@@ -178,6 +179,16 @@ pub fn register_device(input: &str) -> bool {
         // println!("Registering device with product key: {}", input);
         register_device_str(input)
     }
+}
+
+/// Registers a device by vendor and product ID for capture.
+/// The VID:PID is always registered (even if the device is not currently
+/// connected), and the return value indicates whether a matching device
+/// is currently present. This is more reliable than name-based
+/// registration for devices whose product name changes across connect
+/// cycles (common with QMK/Via firmware).
+pub fn register_device_vidpid(vendor_id: u32, product_id: u32) -> bool {
+    unsafe { interface::register_device_vidpid(vendor_id, product_id) }
 }
 
 /// Grabs control of registered devices and starts the monitoring loop


### PR DESCRIPTION
## Summary

Add `register_device_vidpid(vendor_id, product_id)` for matching devices by vendor and product ID instead of product name. This is more reliable for keyboards with QMK/Via firmware whose product name changes across USB connect cycles.

**Problem:** Some keyboards (e.g. Mode M256W-H Alpha with Via firmware) report different `kIOHIDProductKey` values across connect/disconnect cycles — `"T5"` on first plug, `"M256W-H"` after replug. This happens because macOS caches USB string descriptors from the initial enumeration, which can fail or timeout on QMK's ChibiOS USB stack during startup. Since the existing device hash is computed from `vendor_id:product_id:product_name`, the hash changes too, breaking both name-based and hash-based reconnection via `device_connected_callback`.

VID:PID values come from the USB device descriptor (not string descriptors) and are always read correctly.

**Motivation:** This supports the upcoming `macos-continue-if-no-devs-found` feature in kanata ([#1982](https://github.com/jtroo/kanata/issues/1982)), which allows kanata to start before a Bluetooth/USB keyboard is connected and grab it when it appears.

## Changes

- **`registered_device_vidpids`** — new `std::set<uint64_t>` storing packed VID:PID pairs
- **`register_device_vidpid(vendor_id, product_id)`** — unconditionally registers the VID:PID pair (like `register_device_hash`), returns whether device is currently connected
- **`device_connected_vidpid_callback`** — IOKit notification callback that matches new devices by VID:PID instead of hash
- **`capture_registered_devices`** — subscribes to notifications for both hash-registered and VID:PID-registered devices
- **`grab()` / `regrab_input()`** — accept VID:PID registrations in addition to hash registrations
- **Rust FFI** — `register_device_vidpid(vendor_id, product_id) -> bool` wrapper in `lib.rs`

## Test plan

Tested with a Mode M256W-H Alpha keyboard (VID:PID `00DE:5754`, Via firmware):

- [x] `register_device_vidpid(0xDE, 0x5754)` with device disconnected — registers successfully, `grab()` succeeds
- [x] Plug device in — `device_connected_vidpid_callback` fires, device captured instantly
- [x] Keyboard input flows through kanata event loop after capture
- [x] Existing hash-based and name-based registration paths unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)