### PR TITLE
Update VirtualHIDDevice client to v8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Psych3r/driverkit"
 readme = "README.md"
 license = "LGPL-3.0"
 edition = "2021"
+exclude = ["c_src/Karabiner-DriverKit-VirtualHIDDevice/dist/**"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 driverkit is a minimal wrapper around [Karabiner-DriverKit-VirtualHIDDevice (dext)](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice) and [Karabiner-VirtualHIDDevice (kext)](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice) intended for kanata
 macos support.
 
+The DriverKit backend targets Karabiner-DriverKit-VirtualHIDDevice v8.0.0
+(client protocol 7). It is not compatible with older protocol-5 daemons such
+as VirtualHIDDevice v6.2.0.
+
 ## Installation
 
 Update the submodules first

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,9 @@ fn main() {
     build
         .file("c_src/driverkit.cpp")
         .cpp(true)
-        .std("c++2a")
+        // VirtualHIDDevice 8 uses C++23 library APIs such as
+        // std::to_underlying in its Unix-domain stream transport.
+        .std("c++23")
         .flag("-w")
         .shared_flag(true)
         .flag("-fPIC");

--- a/c_src/driverkit.cpp
+++ b/c_src/driverkit.cpp
@@ -643,7 +643,7 @@ extern "C" {
 
 // main function is just for testing
 // build as binary command:
-// g++ c_src/driverkit.cpp -DBUILD_AS_BINARY -Ic_src/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit -Ic_src/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include -Ic_src/Karabiner-DriverKit-VirtualHIDDevice/vendor/vendor/include -std=c++2a -framework IOKit -framework CoreFoundation -o driverkit -g -O0
+// g++ c_src/driverkit.cpp -DBUILD_AS_BINARY -Ic_src/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit -Ic_src/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include -Ic_src/Karabiner-DriverKit-VirtualHIDDevice/vendor/vendor/include -std=c++2b -framework IOKit -framework CoreFoundation -o driverkit -g -O0
 #ifdef BUILD_AS_BINARY
 int main() {
     list_keyboards();

--- a/c_src/driverkit.hpp
+++ b/c_src/driverkit.hpp
@@ -27,6 +27,13 @@
 #else
     #include "virtual_hid_device_driver.hpp"
     #include "virtual_hid_device_service.hpp"
+    // VirtualHIDDevice 8 no longer pulls this type in transitively through
+    // virtual_hid_device_service.hpp.
+    #include <pqrs/osx/iokit_types.hpp>
+    static_assert(
+        type_safe::get(pqrs::karabiner::driverkit::client_protocol_version::embedded_client_protocol_version) == 7,
+        "karabiner-driverkit must be audited before changing VirtualHIDDevice protocol versions"
+    );
     pqrs::karabiner::driverkit::virtual_hid_device_service::client* client;
     // Tracks whether the DriverKit virtual keyboard is ready for output.
     // Written by pqrs dispatcher callbacks, read by the event loop thread.


### PR DESCRIPTION
## Summary

- update the bundled VirtualHIDDevice client from the v6.2-era implementation to the upstream v8.0.0 tag
- compile the wrapper as C++23, as required by v8's Unix-domain stream transport
- explicitly include the pqrs IOKit type used by `driver_activated()`
- add a compile-time guard for client protocol 7
- document the intentional protocol-5 compatibility break
- exclude historical VirtualHID installer packages from the published crate

This prepares the crate for a separate Kanata dependency update. The migration was developed and runtime-tested against current upstream Kanata, without relying on an application-specific fork.

## Why

Karabiner-Elements 16.1 installs VirtualHIDDevice v8, while the current crate is built for the v6.2/protocol-5 client. Current Kanata builds using this crate therefore cannot communicate with the v8 daemon and repeatedly report `connect_failed asio.system:2`.

VirtualHIDDevice v7 changed IPC from local datagrams to Unix-domain streams, and v8 moved the client protocol to 7. Supporting both generations at runtime would require retaining two transports and client implementations. This PR intentionally targets v8 rather than adding that complexity.

## Implementation notes

The v8 update required two wrapper changes beyond the submodule bump:

1. Its Unix-domain stream implementation uses C++23 APIs such as `std::to_underlying`.
2. `virtual_hid_device_service.hpp` no longer transitively includes `pqrs::osx::iokit_mach_port`.

The Rust-facing readiness, input release/re-grab, keyboard report, and pointing report APIs remain unchanged because v8 retains the client signals used by the wrapper.

## Build and package validation

Using upstream `psych3r/driverkit` `main` at `ff62645` as the base:

- `cargo build`
- `cargo test`
- stable Xcode 26.6: `cargo build --all-targets`
- stable Xcode 26.6: `cargo test`
- stable Xcode 26.6: release build of all examples
- `cargo package --allow-dirty`, including rebuilding from the packaged crate
- confirmed the packaged crate contains the protocol-7 headers and Unix-domain stream vendor source
- excluded the 89 MB `dist/` installer archive; the resulting crate is approximately 6.7 MB compressed

The repository currently has no automated runtime tests, so `cargo test` contains zero unit tests.

## Runtime validation

Validated in a disposable macOS 15.7.7 ARM VM with:

- VirtualHIDDevice v8.0.0 installed and `activated enabled`
- upstream Kanata `main` at `c7978d4`
- Kanata built directly against this branch

The following scenarios passed:

- startup with the daemon already running
- startup before the daemon becomes available
- keyboard and pointing-device readiness
- keyboard press and release reports (`send_key` returned success)
- pointing motion and button reports
- daemon termination while Kanata had seized input
- input release while virtual output was unavailable
- daemon restart and in-process recovery
- three consecutive disconnect/reconnect cycles
- clean shutdown
- a new client connecting, seizing input, and sending reports after the previous client exited

During daemon loss, Kanata remained running, marked keyboard and pointing output unavailable, retried the connection, and restored both outputs after the daemon restarted.

### Multiple-client validation

I repeated the same two-client scenario in separate disposable macOS 15.7.7 VMs using current upstream Kanata:

- VirtualHIDDevice v6.2 with the published driverkit crate
- VirtualHIDDevice v8 with this branch

In both environments:

- two Kanata processes connected to the daemon
- both virtual keyboard and pointing clients reached readiness
- both processes remained alive when the daemon stopped
- both recovered in-process after the daemon restarted

Both processes selected the VM's single available keyboard, so one received the expected macOS `exclusive access and device already open` error. Which process received it depended on startup order. This behavior was identical with v6 and v8 and is separate from VirtualHID output-client multiplexing.

This comparison found no multi-client regression from the v6 datagram transport to the v8 Unix-domain stream transport.

## Compatibility

This is an intentional compatibility cut:

- supported daemon: VirtualHIDDevice v8 / client protocol 7
- no compatibility with the older v6 / protocol-5 daemon
- no dual-protocol transport layer added

## Maintainer decisions

Based on maintainer feedback:

- the next release will intentionally target protocol 7 / VirtualHIDDevice v8
- `0.4.0` is the appropriate version for the compatibility break
- the submodule bump, C++23/include changes, and package exclusion should remain together in one commit

The implementation and isolated runtime matrix are complete.
